### PR TITLE
Add old size to laihost_realloc() and laihost_free(): Part 2

### DIFF
--- a/common/laihost.c
+++ b/common/laihost.c
@@ -17,11 +17,13 @@ void *laihost_malloc(size_t size) {
     return malloc(size);
 }
 
-void *laihost_realloc(void *p, size_t size) {
+void *laihost_realloc(void *p, size_t size, size_t oldsize) {
+    (void)oldsize;
     return realloc(p, size);
 }
 
-void laihost_free(void *p) {
+void laihost_free(void *p, size_t size) {
+    (void)size;
     return free(p);
 }
 


### PR DESCRIPTION
Second part of qword-os/lai#86. Should not be merged until the main lai PR is merged, as we don't know which commit it will merge with.